### PR TITLE
It supports simple writing in the case of theta equals theta

### DIFF
--- a/src/main/java/io/github/thiagolvlsantos/json/predicate/impl/PredicateFactoryJson.java
+++ b/src/main/java/io/github/thiagolvlsantos/json/predicate/impl/PredicateFactoryJson.java
@@ -116,7 +116,18 @@ public class PredicateFactoryJson implements IPredicateFactory {
 	private void fields(String gap, List<IPredicate> result, String key, JsonNode value) {
 		Iterator<Entry<String, JsonNode>> fs = value.fields();
 		if (!fs.hasNext()) {
-			throw new JsonPredicateException("Fields for filter not found.", null);
+			String op = "$eq";
+			Class<? extends IPredicate> type = manager.get(op);
+			JsonNode va = value;
+			if (type == null) {
+				throw new JsonPredicateException("Invalid group operator: " + op + " for " + va, null);
+			}
+			if (IPredicateValue.class.isAssignableFrom(type)) {
+				fieldValue(gap, result, key, value, va, type);
+			} else {
+				throw new JsonPredicateException("Invalid group operator: " + op + " is not a value.", null);
+			}
+			return;
 		}
 		while (fs.hasNext()) {
 			Entry<String, JsonNode> f = fs.next();

--- a/src/test/java/io/github/thiagolvlsantos/json/predicate/IssuesTest.java
+++ b/src/test/java/io/github/thiagolvlsantos/json/predicate/IssuesTest.java
@@ -38,4 +38,17 @@ public class IssuesTest {
 		mapData.put("source", "anyvalue");
 		Assert.assertFalse(pred.test(mapData));
 	}
+	@Test
+	public void testEqualsWithoutOpMatch() throws Exception {
+		PredicateFactoryJson factory = new PredicateFactoryJson();
+		Map<String, Object> mapData = new HashMap<>();
+		String rule ="{\"source\":\"weather2\"}";
+                // positive test
+		mapData.put("source", "weather2");
+		Predicate<Object> pred = factory.read(rule.getBytes());
+		Assert.assertTrue(pred.test(mapData));
+		// negative test
+		mapData.put("source", "weather3");
+		Assert.assertFalse(pred.test(mapData));
+	}
 }


### PR DESCRIPTION

//This format {"xxx":"aa"} equivalent to {"xxx":{"$eq":"aa"}} 